### PR TITLE
[FEAT] 공용 모달 컴포넌트

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import React from 'react';
 
 const preview: Preview = {
   parameters: {
@@ -9,6 +10,14 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    Story => (
+      <div>
+        <Story />
+        <div id="root-portal" />
+      </div>
+    ),
+  ],
 };
 
 export default preview;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,6 +36,7 @@ export default function RootLayout({
         <Header />
         <div className={S.container}>{children}</div>
         <Footer />
+        <div id="root-portal" />
       </body>
     </html>
   );

--- a/src/assets/svg/delete.svg
+++ b/src/assets/svg/delete.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-x"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>

--- a/src/components/Modal/Modal.css.ts
+++ b/src/components/Modal/Modal.css.ts
@@ -1,0 +1,20 @@
+import { style } from '@vanilla-extract/css';
+
+export const overlay = style({
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  width: '100%',
+  height: '100%',
+  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+});
+export const modal = style({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  display: 'flex',
+  flexDirection: 'column',
+  width: '500px',
+  backgroundColor: 'white',
+});

--- a/src/components/Modal/Modal.css.ts
+++ b/src/components/Modal/Modal.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const overlay = style({
   position: 'absolute',
@@ -15,6 +15,57 @@ export const modal = style({
   transform: 'translate(-50%, -50%)',
   display: 'flex',
   flexDirection: 'column',
-  width: '500px',
+  maxWidth: '350px',
+  width: '100%',
   backgroundColor: 'white',
+  padding: '10px',
+  gap: '20px',
+  borderRadius: '10px',
+});
+
+export const buttonHeader = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  border: 'none',
+  borderBottom: '1.5px solid black',
+  backgroundColor: 'transparent',
+  paddingBottom: '10px',
+});
+
+export const content = style({
+  display: 'flex',
+  justifyContent: 'center',
+  textAlign: 'center',
+  margin: '10px',
+});
+
+export const buttonFooter = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-around',
+});
+
+export const buttonBase = style({
+  border: 'none',
+  backgroundColor: 'transparent',
+  color: 'white',
+  borderRadius: '4px',
+  maxWidth: '100px',
+  width: '100%',
+  padding: '10px 5px',
+});
+
+export const button = styleVariants({
+  left: [
+    buttonBase,
+    {
+      backgroundColor: 'rgb(196,39,39)',
+    },
+  ],
+  right: [
+    buttonBase,
+    {
+      backgroundColor: 'black',
+    },
+  ],
 });

--- a/src/components/Modal/Portal.tsx
+++ b/src/components/Modal/Portal.tsx
@@ -1,0 +1,13 @@
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: React.ReactNode;
+}
+
+function Portal({ children }: PortalProps) {
+  const element = typeof window !== 'undefined' && document.querySelector(`#root-portal`);
+
+  return element && children ? createPortal(children, element) : null;
+}
+
+export default Portal;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,36 @@
+import DeleteIcon from '@/assets/svg/delete.svg';
+import * as S from '@/components/Modal/Modal.css';
+import Portal from './Portal';
+
+export interface ModalProps {
+  content: string;
+  rightButton: string;
+  leftButton: string;
+  onEvent: () => void;
+  onClose: () => void;
+}
+
+export function Modal(SAMPLE: ModalProps) {
+  const { content, rightButton, leftButton, onEvent, onClose } = SAMPLE;
+
+  return (
+    <Portal>
+      <div className={S.overlay}>
+        <div className={S.modal}>
+          <button className={S.buttonHeader} type="button" onClick={onClose}>
+            <DeleteIcon />
+          </button>
+          <div className={S.content}>{content || '현재 준비 중인 이벤트입니다.'}</div>
+          <span className={S.buttonFooter}>
+            <button type="button" className={S.button.left} onClick={onEvent}>
+              {leftButton}
+            </button>
+            <button type="button" className={S.button.right} onClick={onClose}>
+              {rightButton}
+            </button>
+          </span>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react';
+
+/**
+열기, 닫기, 토글 시나리오에서 사용되는 훅입니다.
+*/
+function useDisclosure(initialState = false) {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const onOpen = useCallback(() => setIsOpen(true), []);
+  const onClose = useCallback(() => setIsOpen(false), []);
+  const onToggle = useCallback(() => setIsOpen(prev => !prev), []);
+
+  return { isOpen, onOpen, onClose, onToggle };
+}
+
+export default useDisclosure;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -16,13 +16,14 @@ type Story = StoryObj<typeof Modal>;
 function Example(arg: ModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
 
   return (
     <div>
       <button type="button" onClick={handleOpen}>
         모달 열기
       </button>
-      {isOpen && <Modal {...arg} />}
+      {isOpen && <Modal {...arg} onClose={handleClose} onEvent={handleClose} />}
     </div>
   );
 }

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ModalProps, Modal } from '@/components/Modal';
+import { useState } from 'react';
+
+const meta = {
+  title: 'Modal',
+  component: Modal,
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+function Example(arg: ModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => setIsOpen(true);
+
+  return (
+    <div>
+      <button type="button" onClick={handleOpen}>
+        모달 열기
+      </button>
+      {isOpen && <Modal {...arg} />}
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: (arg: ModalProps) => <Example {...arg} />,
+  args: {
+    content: '이벤트가 시작되었습니다!',
+    rightButton: '취소',
+    leftButton: '확인',
+    onClose: () => {},
+    onEvent: () => {},
+  },
+};


### PR DESCRIPTION
- Close #21 

## What is this PR? 🔍

- 기능 : 공용 모달 컴포넌트 구현
- issue : #21 

## Changes 📝
<!-- 이번 PR에서의 변경점 -->
- 공용 모달 컴포넌트를 구현했습니다.
- useDisclsure 훅을 추가했습니다.
  - 컴포넌트를 제어할 때 사용하는 훅입니다. ex) 모달, 다이얼로그, Drawer에 사용

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="694" alt="image" src="https://github.com/user-attachments/assets/c1a566cd-f3d6-4909-891e-91c48a2b2460">

## Precaution
 - 다음 브랜치에서 아래의 기능을 추가할 에정입니다.
   - 구조 수정(isOpen에 props 추가 등), 애니메이션, 모달창 외부 클릭하면 창 닫히기 등을 포함할 예정입니다.
## ✔️ Please check if the PR fulfills these requirements

- [X] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [X] If on a hotfix branch, ensure it targets `main`?
- [X] There are no warning message when you run `npm run lint`
