### PR TITLE
[FIX] useCountdownTimer 서버 시간 오차 이슈 해결

### DIFF
--- a/src/apis/types/basicAuction.ts
+++ b/src/apis/types/basicAuction.ts
@@ -68,7 +68,7 @@ export interface PostBasicAuctionResponse extends CommonResponse {
 // -----
 export interface GetBasicAuctionListParams {
   title?: string;
-  sort?: string[];
+  sort?: string;
   page?: number;
   size?: number;
 }

--- a/src/app/basicauction/basicauction.tsx
+++ b/src/app/basicauction/basicauction.tsx
@@ -16,7 +16,7 @@ function BasicAuction() {
 
   const { data } = useGetBasicAuctionList({
     title: searchKeywordParam || '',
-    sort: ['endDate,DESC', 'startDate,ASC'],
+    // sort: '', // ['endDate,DESC', 'startDate,ASC'],
     page: 0,
     size: 10,
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import AuctionList from '@/components/AuctionList';
 export default function Home() {
   const { data } = useGetBasicAuctionList({
     title: '',
-    sort: ['endDate,DESC', 'startDate,ASC'],
+    // sort: '', // ['endDate,DESC', 'startDate,ASC'],
     page: 0,
     size: 4,
   });

--- a/src/components/AuctionInfo/AuctionCountdown.tsx
+++ b/src/components/AuctionInfo/AuctionCountdown.tsx
@@ -13,9 +13,7 @@ function AuctionCountdown({ endTime, setExpired }: AuctionCountdownProps) {
   const { isTimeout, day, hour, minute, second } = useCountdownTimer({ endTime });
 
   useEffect(() => {
-    if (isTimeout) {
-      setExpired(true);
-    }
+    setExpired(isTimeout);
   }, [isTimeout, setExpired]);
 
   return <div className={S.countdownStyle}>{`${day}일 ${hour}시간 ${minute}분 ${second}초`}</div>;

--- a/src/hooks/useCountdownTimer.ts
+++ b/src/hooks/useCountdownTimer.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import calcRemainingTime from '@/utils/calcRemainingTime';
 import { useEffect, useState } from 'react';
 
 interface UseCountdownTimerProps {
@@ -11,23 +12,12 @@ const HOUR_IN_MILLIS = MINUTE_IN_MILLIS * 60;
 const DAY_IN_MILLIS = HOUR_IN_MILLIS * 24;
 
 function useCountdownTimer({ endTime }: UseCountdownTimerProps) {
-  const countRemainingTime = (endTimeInCountRemainingTime: Date) => {
-    const nowTime = new Date();
-
-    if (endTimeInCountRemainingTime.getTime() < nowTime.getTime()) {
-      return 0;
-    }
-
-    return endTimeInCountRemainingTime.getTime() - nowTime.getTime();
-  };
-
-  const [remainingTime, setRemainingTime] = useState<number>(() =>
-    countRemainingTime(new Date(endTime)),
-  );
+  const [remainingTime, setRemainingTime] = useState<number>(0);
 
   useEffect(() => {
+    setRemainingTime(calcRemainingTime(new Date(endTime)));
     const intervalID = setInterval(() => {
-      const remainingTimeInUseEffect = countRemainingTime(new Date(endTime));
+      const remainingTimeInUseEffect = calcRemainingTime(new Date(endTime));
 
       if (remainingTimeInUseEffect <= 0) {
         clearInterval(intervalID);
@@ -41,12 +31,12 @@ function useCountdownTimer({ endTime }: UseCountdownTimerProps) {
     return () => {
       clearInterval(intervalID);
     };
-  });
+  }, []);
 
-  const day = Math.floor(remainingTime / DAY_IN_MILLIS);
-  const hour = Math.floor((remainingTime % DAY_IN_MILLIS) / HOUR_IN_MILLIS);
-  const minute = Math.floor((remainingTime % HOUR_IN_MILLIS) / MINUTE_IN_MILLIS);
-  const second = Math.floor((remainingTime % MINUTE_IN_MILLIS) / 1000);
+  const day = Math.floor(remainingTime / DAY_IN_MILLIS) || '-';
+  const hour = Math.floor((remainingTime % DAY_IN_MILLIS) / HOUR_IN_MILLIS) || '-';
+  const minute = Math.floor((remainingTime % HOUR_IN_MILLIS) / MINUTE_IN_MILLIS) || '-';
+  const second = Math.floor((remainingTime % MINUTE_IN_MILLIS) / 1000) || '-';
   const isTimeout = remainingTime <= 0;
 
   return { isTimeout, remainingTime, day, hour, minute, second };

--- a/src/hooks/useCountdownTimer.ts
+++ b/src/hooks/useCountdownTimer.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import calcRemainingTime from '@/utils/calcRemainingTime';
 import { useEffect, useState } from 'react';
+
+import calcRemainingTime from '@/utils/calcRemainingTime';
 
 interface UseCountdownTimerProps {
   endTime: Date | string;

--- a/src/utils/calcRemainingTime.ts
+++ b/src/utils/calcRemainingTime.ts
@@ -1,0 +1,11 @@
+function calcRemainingTime(endTimeInCountRemainingTime: Date) {
+  const nowTime = new Date();
+
+  if (endTimeInCountRemainingTime.getTime() < nowTime.getTime()) {
+    return 0;
+  }
+
+  return endTimeInCountRemainingTime.getTime() - nowTime.getTime();
+}
+
+export default calcRemainingTime;


### PR DESCRIPTION
- Close #42 

## What is this PR? 🔍

- 기능 : useCountdownTimer 서버 시간 오차 이슈 해결
- issue : #42 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
* countdown에 들어갈 시간 요소를 마운트 시점 이후에 계산하여 넣는 방향으로 수정하였습니다.
* countdown을 하는 로직을 hook에서 분리해내고 util 쪽으로 이동하였습니다.
* 마운트 이후 시전에서 countdown을 진행하기에 초기에 시간이 바로 보이지 않습니다. 따라서 '-'로 표시하고 이후에 타이머가 on 되도록 하였습니다.

## ScreenShot 📷
![tttt](https://github.com/user-attachments/assets/95a539d2-56df-4834-8ac5-763313e6bed8)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `npm run lint`
