### PR TITLE
[FEAT] 입찰 삭제 구현(현재 userID가 없어 const값으로 진행)

### DIFF
--- a/src/apis/queryFunctions/basicAuction.ts
+++ b/src/apis/queryFunctions/basicAuction.ts
@@ -50,3 +50,9 @@ export const postBasicAuctionBid = async (id: number, param: PostBasicAuctionBid
 
   return response.data;
 };
+
+export const deleteAuction = async (id: number) => {
+  const response = await apiClient.delete<Response<null>>(`/v1/auction/${id}`);
+
+  return response.data;
+};

--- a/src/apis/queryHooks/basicAuction/useDeleteBasicAuction.ts
+++ b/src/apis/queryHooks/basicAuction/useDeleteBasicAuction.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useRouter } from 'next/navigation';
+
+import { deleteAuction } from '@/apis/queryFunctions/basicAuction';
+import { Response } from '@/apis/types/common';
+
+function useDeleteBasicAuction() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const { mutate, error } = useMutation({
+    mutationFn: (id: number) => deleteAuction(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['basicAuctionList'] });
+      router.push('/basicauction');
+    },
+    onError: (e: AxiosError<Response<string>>) => {
+      if (e.response) {
+        alert(`${e.response.data.result_msg}`);
+      } else {
+        // 네트워크 에러나 기타 처리되지 않은 에러 처리
+        console.log('알 수 없는 오류 발생', e.message);
+        alert('알 수 없는 오류가 발생했습니다.');
+      }
+    },
+  });
+
+  return { mutate, error };
+}
+
+export default useDeleteBasicAuction;

--- a/src/components/AuctionInfo/AuctionDeleteConfirmModal.tsx
+++ b/src/components/AuctionInfo/AuctionDeleteConfirmModal.tsx
@@ -1,0 +1,3 @@
+export default function AuctionDeleteConfirmModal() {
+  return <div>해당 경매를 삭제하시겠습니까?</div>;
+}

--- a/src/components/AuctionInfo/AuctionInfo.css.ts
+++ b/src/components/AuctionInfo/AuctionInfo.css.ts
@@ -83,6 +83,30 @@ export const bidButton = styleVariants({
   },
 });
 
+export const deleteButton = styleVariants({
+  default: {
+    marginTop: '20px',
+    background: 'red',
+    color: '#F0F0F0',
+    borderRadius: '4px',
+    border: 'none',
+    cursor: 'pointer',
+    height: '80px',
+    fontSize: '16px',
+    padding: '24px 24px',
+  },
+  disabled: {
+    fontSize: '14px',
+    padding: '24px 24px',
+    marginTop: '12px',
+    borderRadius: '4px',
+    border: 'none',
+    backgroundColor: 'darkred',
+    color: 'darkgray',
+    cursor: 'not-allowed',
+  },
+});
+
 export const bidButtonExplain = style({
   marginTop: '4px',
   fontSize: '12px',

--- a/src/components/AuctionInfo/AuctionInfo.css.ts
+++ b/src/components/AuctionInfo/AuctionInfo.css.ts
@@ -97,11 +97,8 @@ export const deleteButton = styleVariants({
   },
   disabled: {
     fontSize: '14px',
-    padding: '24px 24px',
     marginTop: '12px',
-    borderRadius: '4px',
     border: 'none',
-    backgroundColor: 'darkred',
     color: 'darkgray',
     cursor: 'not-allowed',
   },

--- a/src/components/AuctionInfo/index.tsx
+++ b/src/components/AuctionInfo/index.tsx
@@ -32,7 +32,7 @@ function AuctionInfo(SAMPLE: AuctionInfoProps) {
   const { token } = useAuth();
   const { id, title, startPrice, nowPrice, bidCount, endTime, bidUnit } = SAMPLE;
   const { mutate: postBidMutate } = usePostBasicAuctionBid();
-  const { mutate: deleteAuctionMutate } = useDeleteBasicAuction(); /// usePostBasicAuctionBid();
+  const { mutate: deleteAuctionMutate } = useDeleteBasicAuction();
 
   const [expired, setExpired] = useState(false);
   const bidInputRef = useRef<HTMLInputElement>(null);
@@ -75,11 +75,6 @@ function AuctionInfo(SAMPLE: AuctionInfoProps) {
       });
     }
     setIsOpenBidConfirmModal();
-  };
-
-  const handleDeleteButton = () => {
-    console.log('delete');
-    deleteAuctionMutate(id);
   };
 
   const handleBidPriceDown = () => {
@@ -212,7 +207,7 @@ function AuctionInfo(SAMPLE: AuctionInfoProps) {
         isOpen={isOpenDeleteConfirmModal}
         onOpenChange={setIsOpenDeleteConfirmModal}
         positiveButton="삭제"
-        positiveButtonEvent={handleDeleteButton}
+        positiveButtonEvent={() => deleteAuctionMutate(id)}
       >
         <AuctionDeleteConfirmModal />
       </ModalFooter>


### PR DESCRIPTION
- Close #50 

## What is this PR? 🔍

- 기능 : 입찰 삭제 구현(현재 userID가 없어 const값으로 진행)
- issue : #50 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
* 입찰 삭제를 구현합니다.
    * 해당 게시글에 입찰 내역이 없을 경우에만 삭제가 가능합니다.
    * 해당 게시글을 작성자만 게시글을 삭제할 수 있습니다. 

## ScreenShot 📷
![스크린샷 2024-10-11 오후 5 46 08](https://github.com/user-attachments/assets/d982f918-0266-4743-be29-4ea0f0d52b97)
![스크린샷 2024-10-11 오후 5 46 16](https://github.com/user-attachments/assets/4ddae5a8-a567-4d8d-a88f-37aa7003cd8a)
![스크린샷 2024-10-11 오후 5 46 49](https://github.com/user-attachments/assets/d7a02389-1b71-46df-a0ba-b4187631267f)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
* 현재 유저 id를 가져오는 요소와 게시글 작성자 id를 가져오는 속성이 없기에 const 값을 넣어서 진행하였습니다. 해당 부분은 api 수정 후 추가 적으로 약간 변경이 필요합니다.
* 게시글 작성자가 입찰을 걸 수 없기에 `[입찰하기]`버튼에 삭제하기를 구현하였습니다.
* bid가 하나라도 걸리면 삭제가 불가능하기에 disable 처리 하였습니다.
* 겹치는 부분이 많습니다.. 빠르게 기능 개발을 하고 코드 수정 진행하겠습니다.(AuctionInfo 부분도 사이즈를 줄여야할 것 같습니다아..)

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `npm run lint`
