### PR TITLE
[FIX] 이메일 중복 에러 수정

### DIFF
--- a/src/apis/queryHooks/Auth/useGetEmailValidation.ts
+++ b/src/apis/queryHooks/Auth/useGetEmailValidation.ts
@@ -3,13 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import { getEmailValidation } from '@/apis/queryFunctions/Auth';
 
 function useGetEmailValidation(email: string | null) {
-  const { data, refetch } = useQuery({
+  const { data, error } = useQuery({
     queryKey: ['email', email],
     queryFn: () => getEmailValidation({ email }),
     enabled: !!email,
+    retry: false,
   });
 
-  return { data: data?.result_data, refetch };
+  return { data: data?.result_data, error };
 }
 
 export default useGetEmailValidation;


### PR DESCRIPTION
- Close #83 

## What is this PR? 🔍

- 기능 : 이메일 중복 에러 수정
- issue : #83 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 이메일 중복 에러 처리 수정했습니다.
- 두 종류의 상태값으로 유효성 검사 및 중복 검사를 진행합니다. 
   - `emailValidationCheck` - 이메일 유효성 검사
   - `emailApiCheck` - 이메일 중복 검사
## ScreenShot 📷
<img width="442" alt="image" src="https://github.com/user-attachments/assets/4baf8321-6e0d-47e5-a2c8-23a2e65bfbf0">

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution
- useQuery는 컴포넌트 최상위에서 호출해야 하기 때문에 null 값을 활용해 api 호출을 조절했습니다.
## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `npm run lint`
