### PR TITLE
[FEAT] 즉시 구매 api 연동

### DIFF
--- a/src/apis/queryFunctions/basicAuction.ts
+++ b/src/apis/queryFunctions/basicAuction.ts
@@ -59,6 +59,12 @@ export const postBasicAuctionBid = async (id: number, param: PostBasicAuctionBid
   return response.data;
 };
 
+export const postBasicAuctionInstantBuy = async (id: number) => {
+  const response = await apiClient.post<Response<null>>(`/v2/bids/${id}/instant-buy`);
+
+  return response.data;
+};
+
 export const deleteAuction = async (id: number) => {
   const response = await apiClient.delete<Response<null>>(`/v2/auctions/${id}`);
 

--- a/src/apis/queryHooks/basicAuction/usePostBasicAuctionInstantBuy.ts
+++ b/src/apis/queryHooks/basicAuction/usePostBasicAuctionInstantBuy.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { postBasicAuctionInstantBuy } from '@/apis/queryFunctions/basicAuction';
+import { Response } from '@/apis/types/common';
+import { useToast } from '@/provider/toastProvider';
+
+function usePostBasicAuctionInstantBuy(id: number) {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const { mutate, error } = useMutation({
+    mutationFn: () => postBasicAuctionInstantBuy(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['basicAuction', id] });
+      queryClient.invalidateQueries({ queryKey: ['basicAuctionList'] });
+      queryClient.invalidateQueries({ queryKey: ['basicAuctionBidList', id] });
+      queryClient.invalidateQueries({ queryKey: ['bidAuctionHistories'] });
+      // queryClient.invalidateQueries({ queryKey: ['nowPrice', params.id] });
+      showToast('success', '입찰에 성공했습니다.');
+    },
+    onError: (e: AxiosError<Response<string>>) => {
+      queryClient.invalidateQueries({ queryKey: ['nowPrice', id] });
+      if (e.response) {
+        showToast('error', `${e.response.data.result_msg}`);
+      } else {
+        showToast('error', '알 수 없는 오류가 발생했습니다. 새로고침을 진행해 주세요.');
+      }
+    },
+  });
+
+  return { mutate, error };
+}
+
+export default usePostBasicAuctionInstantBuy;

--- a/src/apis/types/basicAuction.ts
+++ b/src/apis/types/basicAuction.ts
@@ -18,6 +18,7 @@ export type BasicAuctionResponseData = {
   is_liked: boolean;
   like_count: number;
   categories: Category[];
+  instant_buy_price: number | null;
 };
 
 export interface AuctionData {

--- a/src/app/basicauction/[id]/BasicAuctionInfo.css.ts
+++ b/src/app/basicauction/[id]/BasicAuctionInfo.css.ts
@@ -2,6 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const auctionInfoWrapper = style({
   padding: '30px 0',
+  gap: '20px',
   display: 'grid',
   gridTemplateColumns: 'minmax(510px, 1fr) minmax(430px, 1fr)',
   '@media': {

--- a/src/app/basicauction/[id]/BasicAuctionInfo.tsx
+++ b/src/app/basicauction/[id]/BasicAuctionInfo.tsx
@@ -51,6 +51,7 @@ function BasicAuctionInfo({ id }: BasicAuctionInfoProps) {
           bidCount={data.result_data.bid_count}
           bidUnit={data.result_data.bid_unit}
           sellerId={data.result_data.member_id}
+          instantBuyPrice={data.result_data.instant_buy_price}
         />
       </div>
       <TabsLayout

--- a/src/app/basicauction/[id]/BasicAuctionInfo.tsx
+++ b/src/app/basicauction/[id]/BasicAuctionInfo.tsx
@@ -52,6 +52,7 @@ function BasicAuctionInfo({ id }: BasicAuctionInfoProps) {
           bidUnit={data.result_data.bid_unit}
           sellerId={data.result_data.member_id}
           instantBuyPrice={data.result_data.instant_buy_price}
+          auctionStatus={data.result_data.auction_status}
         />
       </div>
       <TabsLayout

--- a/src/app/mypage/heart/page.tsx
+++ b/src/app/mypage/heart/page.tsx
@@ -41,6 +41,7 @@ function Home() {
             startTime={item.start_date}
             endTime={item.end_date}
             nowPrice={item.now_price}
+            auctionStatus={item.auction_status}
           />
         ))}
         {/* {data?.pages.map(page =>

--- a/src/components/AuctionCard/index.tsx
+++ b/src/components/AuctionCard/index.tsx
@@ -31,7 +31,7 @@ function AuctionCard(SAMPLE: AuctionCardProps) {
     nowPrice,
     auctionStatus,
   } = SAMPLE;
-  console.log(SAMPLE);
+
   const isExpired = auctionStatus !== 'BIDDING'; // new Date() > new Date(endTime);
   const [isLike, setIsLike] = useState(false); // 서버와 클라이언트의 불일치 문제 해결을 위해 isLike를 상태로 관리
   const dDay = calculateDDay(endTime);

--- a/src/components/AuctionCard/index.tsx
+++ b/src/components/AuctionCard/index.tsx
@@ -18,11 +18,21 @@ interface AuctionCardProps {
   startTime: string;
   endTime: string;
   nowPrice: number | null;
+  auctionStatus: string;
 }
 
 function AuctionCard(SAMPLE: AuctionCardProps) {
-  const { id, thumbnailImage, title, isLike: initialLike, endTime, nowPrice } = SAMPLE;
-  const isExpired = new Date() > new Date(endTime);
+  const {
+    id,
+    thumbnailImage,
+    title,
+    isLike: initialLike,
+    endTime,
+    nowPrice,
+    auctionStatus,
+  } = SAMPLE;
+  console.log(SAMPLE);
+  const isExpired = auctionStatus !== 'BIDDING'; // new Date() > new Date(endTime);
   const [isLike, setIsLike] = useState(false); // 서버와 클라이언트의 불일치 문제 해결을 위해 isLike를 상태로 관리
   const dDay = calculateDDay(endTime);
   const { mutate: postAuctionLike } = usePostAuctionLike(id, isLike);

--- a/src/components/AuctionInfo/AuctionCountdown.tsx
+++ b/src/components/AuctionInfo/AuctionCountdown.tsx
@@ -14,7 +14,18 @@ function AuctionCountdown({ auctionStatus, endTime, setExpired }: AuctionCountdo
   const { isTimeout, day, hour, minute, second } = useCountdownTimer({ endTime });
 
   useEffect(() => {
-    if (auctionStatus === 'BIDDING' || auctionStatus === 'NO_BIDS') setExpired('expired');
+    if (auctionStatus === 'CONCLUDED') {
+      setExpired('concluded');
+    }
+    if (auctionStatus === 'COMPLETE') {
+      setExpired('completed');
+    }
+    if ((auctionStatus === 'BIDDING' || auctionStatus === 'NO_BIDS') && isTimeout) {
+      setExpired('expired');
+    }
+    if ((auctionStatus === 'BIDDING' || auctionStatus === 'NO_BIDS') && !isTimeout) {
+      setExpired('');
+    }
   }, [isTimeout, setExpired]);
 
   return <div className={S.countdownStyle}>{`${day}일 ${hour}시간 ${minute}분 ${second}초`}</div>;

--- a/src/components/AuctionInfo/AuctionCountdown.tsx
+++ b/src/components/AuctionInfo/AuctionCountdown.tsx
@@ -6,14 +6,15 @@ import * as S from './AuctionCountdown.css';
 
 interface AuctionCountdownProps {
   endTime: Date | string;
-  setExpired: Dispatch<SetStateAction<boolean>>;
+  setExpired: Dispatch<SetStateAction<string>>;
+  auctionStatus: string;
 }
 
-function AuctionCountdown({ endTime, setExpired }: AuctionCountdownProps) {
+function AuctionCountdown({ auctionStatus, endTime, setExpired }: AuctionCountdownProps) {
   const { isTimeout, day, hour, minute, second } = useCountdownTimer({ endTime });
 
   useEffect(() => {
-    setExpired(isTimeout);
+    if (auctionStatus === 'BIDDING' || auctionStatus === 'NO_BIDS') setExpired('expired');
   }, [isTimeout, setExpired]);
 
   return <div className={S.countdownStyle}>{`${day}일 ${hour}시간 ${minute}분 ${second}초`}</div>;

--- a/src/components/AuctionInfo/AuctionInfo.css.ts
+++ b/src/components/AuctionInfo/AuctionInfo.css.ts
@@ -9,9 +9,11 @@ export const infoWrapper = style({
   flexDirection: 'column',
   padding: '12px',
   width: '100%',
+  maxWidth: '440px',
   '@media': {
     'screen and (max-width: 960px)': {
       marginLeft: '0px',
+      maxWidth: 'none',
     },
   },
 });
@@ -91,12 +93,18 @@ export const infoButton = style({
   cursor: 'pointer',
 });
 
+export const bidButtonWrapper = style({
+  display: 'flex',
+  // flexDirection: 'column',
+  gap: '12px',
+  marginTop: '12px',
+});
+
 export const bidButton = styleVariants({
   default: {
-    height: '80px',
-    fontSize: '16px',
-    padding: '24px 24px',
-    marginTop: '12px',
+    width: '100%',
+    height: '50px',
+    fontSize: '14px',
     backgroundColor: colors.primary10,
     color: colors.primary1,
     borderRadius: '8px',
@@ -104,10 +112,10 @@ export const bidButton = styleVariants({
     cursor: 'pointer',
   },
   disabled: {
+    width: '100%',
+    height: '50px',
     fontSize: '14px',
-    padding: '24px 24px',
-    marginTop: '12px',
-    borderRadius: '4px',
+    borderRadius: '8px',
     border: 'none',
     backgroundColor: 'gray',
     color: 'darkgray',

--- a/src/components/AuctionInfo/AuctionInfo.css.ts
+++ b/src/components/AuctionInfo/AuctionInfo.css.ts
@@ -95,7 +95,6 @@ export const infoButton = style({
 
 export const bidButtonWrapper = style({
   display: 'flex',
-  // flexDirection: 'column',
   gap: '12px',
   marginTop: '12px',
 });
@@ -125,22 +124,22 @@ export const bidButton = styleVariants({
 
 export const deleteButton = styleVariants({
   default: {
-    marginTop: '20px',
+    width: '100%',
+    height: '50px',
+    fontSize: '14px',
     backgroundColor: colors.primary10,
     color: colors.primary1,
     borderRadius: '8px',
     border: 'none',
     cursor: 'pointer',
-    height: '80px',
-    fontSize: '16px',
-    padding: '24px 24px',
   },
   disabled: {
-    padding: '24px 24px',
-    marginTop: '12px',
-    borderRadius: '4px',
+    width: '100%',
+    height: '50px',
+    fontSize: '14px',
+    borderRadius: '8px',
     border: 'none',
-    backgroundColor: 'darkred',
+    backgroundColor: 'gray',
     color: 'darkgray',
     cursor: 'not-allowed',
   },

--- a/src/components/AuctionInfo/AuctionInstantBuyConfirmModal.tsx
+++ b/src/components/AuctionInfo/AuctionInstantBuyConfirmModal.tsx
@@ -1,0 +1,9 @@
+interface AuctionInstantBuyConfirmModalProps {
+  InstantBuyPrice: number;
+}
+
+export default function AuctionInstantBuyConfirmModal({
+  InstantBuyPrice,
+}: AuctionInstantBuyConfirmModalProps) {
+  return <div>{`${InstantBuyPrice} 원에 입찰을 진행하시겠습니까?`}</div>;
+}

--- a/src/components/AuctionInfo/hooks/usePermissionBidPrice.ts
+++ b/src/components/AuctionInfo/hooks/usePermissionBidPrice.ts
@@ -6,11 +6,14 @@ import { useAuth } from '@/provider/authProvider';
 export function usePermissionBidPrice(sellerId: number) {
   const { isLoggedIn } = useAuth();
   const { data: user } = useGetUser();
-  const [expired, setExpired] = useState(false);
+  const [expired, setExpired] = useState('');
 
   const canNotBid = () => {
-    if (expired) {
+    if (expired === 'expired') {
       return '경매 진행 기간이 아닙니다.';
+    }
+    if (expired === 'concluded' || expired === 'completed') {
+      return '완료된 경매입니다.';
     }
     if (!isLoggedIn) {
       return '로그인 후 사용 가능한 서비스입니다.';

--- a/src/components/AuctionInfo/index.tsx
+++ b/src/components/AuctionInfo/index.tsx
@@ -28,10 +28,12 @@ interface AuctionInfoProps {
   bidCount: number;
   bidUnit: number;
   sellerId: number;
+  instantBuyPrice: number | null;
 }
 
 function AuctionInfo(props: AuctionInfoProps) {
-  const { id, title, startPrice, nowPrice, bidCount, endTime, bidUnit, sellerId } = props;
+  const { id, title, startPrice, nowPrice, bidCount, endTime, bidUnit, sellerId, instantBuyPrice } =
+    props;
 
   const { mutate: postBidMutate } = usePostBasicAuctionBid();
   const { mutate: deleteAuctionMutate } = useDeleteBasicAuction();
@@ -186,15 +188,28 @@ function AuctionInfo(props: AuctionInfoProps) {
           )}
         </button>
       ) : (
-        <button
-          disabled={expired || !user}
-          type="button"
-          className={expired || !user ? S.bidButton.disabled : S.bidButton.default}
-          onClick={openBidConfirmModal}
-        >
-          입찰하기
-          <p className={S.bidButtonExplain}>{canNotBid()}</p>
-        </button>
+        <div className={S.bidButtonWrapper}>
+          <button
+            disabled={expired || !user}
+            type="button"
+            className={expired || !user ? S.bidButton.disabled : S.bidButton.default}
+            onClick={openBidConfirmModal}
+          >
+            입찰하기
+            <p className={S.bidButtonExplain}>{canNotBid()}</p>
+          </button>
+          {instantBuyPrice && (
+            <button
+              disabled={expired || !user}
+              type="button"
+              className={expired || !user ? S.bidButton.disabled : S.bidButton.default}
+              onClick={openBidConfirmModal}
+            >
+              즉시 구매하기
+              <p className={S.bidButtonExplain}>{canNotBid()}</p>
+            </button>
+          )}
+        </div>
       )}
 
       <ModalFooter

--- a/src/components/AuctionInfo/index.tsx
+++ b/src/components/AuctionInfo/index.tsx
@@ -95,8 +95,6 @@ function AuctionInfo(props: AuctionInfoProps) {
     }
   }, [auctionStatus]);
 
-  console.log('AuctionInfo canNotBid', auctionStatus, canNotBid());
-
   const handleBidButton = useDebounce(() => {
     if (bidInputRef.current) {
       const bidAmount = bidInputRef.current.value;

--- a/src/components/AuctionList/index.tsx
+++ b/src/components/AuctionList/index.tsx
@@ -40,6 +40,7 @@ export default function AuctionList({ data, isLink, path = '', pathname }: Aucti
               startTime={item.start_date}
               endTime={item.end_date}
               nowPrice={item.now_price}
+              auctionStatus={item.auction_status}
             />
           ))}
         </ListLayout>

--- a/src/components/BasicAuctionClientPage/index.tsx
+++ b/src/components/BasicAuctionClientPage/index.tsx
@@ -44,6 +44,7 @@ function BasicAuctionClientPage() {
             startTime={item.start_date}
             endTime={item.end_date}
             nowPrice={item?.now_price}
+            auctionStatus={item.auction_status}
           />
         ))}
       </ListLayout>


### PR DESCRIPTION
- Close #122 

## What is this PR? 🔍

- 기능 : 즉시 구매 기능 추가
- issue : #122 

## Changes 📝

* 즉시구매 api 를 추가하였습니다.
* 입찰하기 버튼 섹션에 가로로 즉시구매가가 있는 경매의 경우 즉시구매 버튼을 나타냈습니다.
* canNotBid 관련 에러 문구에 concluded와 completed인 상태에 대한 로직을 추가하였습니다.

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

#### 기간이 끝나지 않았지만 즉시구매로 경매가 완료 된 경우
![스크린샷 2024-11-20 오전 1 35 50](https://github.com/user-attachments/assets/51973d6d-75f8-4215-9220-11cd0b009e18)

#### NO_BIDS상태로 경매 기간이 끝난 경우
![스크린샷 2024-11-20 오전 1 36 00](https://github.com/user-attachments/assets/00b0822c-d008-4f39-b00c-07dceb681d22)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

해당 파트는 수요일 QA에 함께 들어가야할 파트여서 빠르게 구현하였습니다.
(이미 게시글 생성때 즉시 구매 요소가 들어있기 때문에 빠질 수 없는 기능이었습니다.. 말씀 드리기 머해서 걍 만들었습니다~!)

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `npm run lint`
