### PR TITLE
[FEAT] 이메일 인증 추가

### DIFF
--- a/src/apis/queryFunctions/Auth.ts
+++ b/src/apis/queryFunctions/Auth.ts
@@ -4,6 +4,8 @@ import {
   RegisterParams,
   CheckEmailParams,
   PostRegisterResponseData,
+  PostEmailAuthParams,
+  CheckEmailAuthParams,
 } from '@/apis/types/Auth';
 import { Response } from '@/apis/types/common';
 
@@ -21,5 +23,15 @@ export const getEmailValidation = async (params: CheckEmailParams) => {
   const response = await apiClient.get<Response<boolean>>('v2/auth/validate-email', {
     params,
   });
+  return response.data;
+};
+
+export const postEmailAuth = async (params: PostEmailAuthParams) => {
+  const response = await apiClient.post<Response<null>>('v2/mail', params);
+  return response.data;
+};
+
+export const postEmailValidationCode = async (params: CheckEmailAuthParams) => {
+  const response = await apiClient.post<Response<boolean>>('v2/mail/code', params);
   return response.data;
 };

--- a/src/apis/queryHooks/Auth/useCheckEmailAuthCode.ts
+++ b/src/apis/queryHooks/Auth/useCheckEmailAuthCode.ts
@@ -16,7 +16,7 @@ function useCheckEmailAuthCode(setIsOpenAuthCode: (isOpen: boolean) => void) {
         showToast('success', '이메일 인증이 완료되었습니다.');
         setIsOpenAuthCode(false);
       } else {
-        showToast('error', '인증번호가 일치하지 않습니다');
+        showToast('error', '인증코드가 일치하지 않습니다');
       }
     },
     onError: (e: AxiosError<Response<string>>) => {

--- a/src/apis/queryHooks/Auth/useCheckEmailAuthCode.ts
+++ b/src/apis/queryHooks/Auth/useCheckEmailAuthCode.ts
@@ -1,0 +1,35 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { postEmailValidationCode } from '@/apis/queryFunctions/Auth';
+import { CheckEmailAuthParams } from '@/apis/types/Auth';
+import { Response } from '@/apis/types/common';
+import { useToast } from '@/provider/toastProvider';
+
+function useCheckEmailAuthCode(setIsOpenAuthCode: (isOpen: boolean) => void) {
+  const { showToast } = useToast();
+
+  const { data, mutate, error } = useMutation({
+    mutationFn: (params: CheckEmailAuthParams) => postEmailValidationCode(params),
+    onSuccess: responseData => {
+      if (responseData.result_data) {
+        showToast('success', '이메일 인증이 완료되었습니다.');
+        setIsOpenAuthCode(false);
+      } else {
+        showToast('error', '인증번호가 일치하지 않습니다');
+      }
+    },
+    onError: (e: AxiosError<Response<string>>) => {
+      if (e.response) {
+        showToast('error', `${e.response.data.result_msg}`);
+      } else {
+        // 네트워크 에러나 기타 처리되지 않은 에러 처리
+        showToast('error', '알 수 없는 오류가 발생했습니다. 새로고침을 진행해 주세요.');
+      }
+    },
+  });
+
+  return { data: data!, mutate, error };
+}
+
+export default useCheckEmailAuthCode;

--- a/src/apis/queryHooks/Auth/usePostEmailAuth.ts
+++ b/src/apis/queryHooks/Auth/usePostEmailAuth.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { postEmailAuth } from '@/apis/queryFunctions/Auth';
+import { Response } from '@/apis/types/common';
+import { useToast } from '@/provider/toastProvider';
+
+function usePostEmailAuth(setIsOpenAuthCode: (isOpen: boolean) => void) {
+  const { showToast } = useToast();
+
+  const { mutate, error } = useMutation({
+    mutationFn: (email: string) => postEmailAuth({ email }),
+    onSuccess: () => {
+      setIsOpenAuthCode(true);
+      showToast('success', '인증번호가 발송되었습니다.');
+    },
+    onError: (e: AxiosError<Response<string>>) => {
+      if (e.response) {
+        showToast('error', `${e.response.data.result_msg}`);
+      } else {
+        // 네트워크 에러나 기타 처리되지 않은 에러 처리
+        showToast('error', '알 수 없는 오류가 발생했습니다. 새로고침을 진행해 주세요.');
+      }
+    },
+  });
+
+  return { mutate, error };
+}
+
+export default usePostEmailAuth;

--- a/src/apis/types/Auth.ts
+++ b/src/apis/types/Auth.ts
@@ -20,3 +20,12 @@ export interface LoginParams {
 export interface CheckEmailParams {
   email: string;
 }
+
+export interface PostEmailAuthParams {
+  email: string;
+}
+
+export interface CheckEmailAuthParams {
+  email: string;
+  code: string;
+}

--- a/src/app/join/Join.css.ts
+++ b/src/app/join/Join.css.ts
@@ -44,7 +44,7 @@ export const inputSection = style({
 export const emailSection = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: '8px',
+  gap: '10px',
 });
 
 export const commonInputContainer = style({
@@ -146,5 +146,5 @@ export const buttonWrapper = style({
 
 export const duplicateCheckButtonWrapper = style({
   display: 'flex',
-  minWidth: '80px',
+  minWidth: '100px',
 });

--- a/src/app/join/Join.css.ts
+++ b/src/app/join/Join.css.ts
@@ -1,8 +1,9 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 import colors from '@/styles/color';
 import layout from '@/styles/layout';
 import shadow from '@/styles/shadow';
+import typography from '@/styles/typo';
 
 export const backContainer = style({
   display: 'flex',
@@ -57,85 +58,12 @@ export const blind = style({
   top: '38px',
 });
 
-export const inputLabel = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '6px',
-});
-
-export const joinInput = style({
-  display: 'flex',
-  borderRadius: '4px',
-  padding: '12px 16px',
-  alignItems: 'flex-start',
-  gap: '8px',
-  border: '1.5px solid black',
-  background: '#FFF',
-});
-
-export const inputValidation = style({
-  display: 'flex',
-  gap: '4px',
-  alignItems: 'center',
-  color: '#FF0000',
-  fontSize: '14px',
-  marginLeft: '8px',
-});
-
 export const error = style({
-  color: '#FF0000',
-});
-
-export const correct = style({
-  color: 'green',
-});
-
-export const submitButton = style({
-  marginTop: '30px',
-  width: '402px',
-  padding: '15px 62px',
-  background: 'black ',
-  color: '#FFF',
-  fontSize: '16px',
-  borderRadius: '4px',
-  border: 'none',
-  cursor: 'pointer',
-});
-
-const buttonBase = style({
   display: 'flex',
-  color: '#FFF',
-  justifyItems: 'flex-end',
-  fontSize: '14px',
-  width: '80px',
-  height: '44px',
   alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: '4px',
-  cursor: 'pointer',
-});
-
-export const checkButton = styleVariants({
-  default: [
-    buttonBase,
-    {
-      background: 'black',
-    },
-  ],
-  disabled: [
-    buttonBase,
-    {
-      background: '#C4C4C4',
-      cursor: 'not-allowed',
-    },
-  ],
-  confirm: [
-    buttonBase,
-    {
-      background: '#C4C4C4',
-      cursor: 'not-allowed',
-    },
-  ],
+  gap: '4px',
+  fontSize: '14px',
+  color: colors.primary10,
 });
 
 export const buttonWrapper = style({
@@ -144,7 +72,34 @@ export const buttonWrapper = style({
   marginTop: '30px',
 });
 
-export const duplicateCheckButtonWrapper = style({
+export const checkEmailAuthCodeButton = style({
   display: 'flex',
   minWidth: '100px',
+});
+
+export const emailDescription = style({
+  ...typography.caption,
+  position: 'relative',
+  display: 'flex',
+  gap: '5px',
+  alignItems: 'center',
+  color: colors.gray9,
+  fontStyle: 'italic',
+});
+
+export const emailSendButton = style({
+  ...typography.caption,
+  color: colors.gray9,
+  textDecoration: 'underline',
+  fontStyle: 'italic',
+  cursor: 'pointer',
+});
+
+export const timer = style({
+  position: 'absolute',
+  display: 'flex',
+  alignItems: 'center',
+  right: '5px',
+  color: colors.red,
+  fontStyle: 'normal',
 });

--- a/src/app/join/components/authcodetimer.tsx
+++ b/src/app/join/components/authcodetimer.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+import { AsteriskIcon } from 'lucide-react';
+
+import * as S from '../Join.css';
+
+interface AuthCodeTimerProps {
+  count: number;
+  setCount: (count: number) => void;
+}
+
+function AuthCodeTimer({ count, setCount }: AuthCodeTimerProps) {
+  const formatTime = (time: number) => {
+    const minutes = Math.floor(time / 60);
+    const seconds = time % 60;
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  };
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCount(count - 1);
+    }, 1000);
+
+    if (count === 0) {
+      clearInterval(id);
+    }
+    return () => {
+      clearInterval(id);
+    };
+  });
+
+  return (
+    <div className={S.timer}>
+      <AsteriskIcon size={12} /> {formatTime(count)}
+    </div>
+  );
+}
+
+export default AuthCodeTimer;

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -40,6 +40,7 @@ function Home() {
     register,
     handleSubmit,
     watch,
+    setValue,
     formState: { errors },
   } = useForm<JoinInputs>({
     mode: 'onChange',
@@ -60,14 +61,22 @@ function Home() {
     useCheckEmailAuthCode(setIsOpenAuthCode);
   const { mutate: join } = usePostRegister();
 
-  const handleEmailAuth = () => {
+  const handleEmailAuth = (type: 'first' | 'resend') => {
     if (emailRequired === '') return;
 
     if (!checkEmailError) {
-      postEmailAuth(emailRequired);
-
-      if (count === 0) {
+      if (type === 'first') {
+        postEmailAuth(emailRequired);
         setCount(DB_TIME);
+        setValue('authCodeRequired', '');
+      }
+
+      if (type === 'resend') {
+        postEmailAuth(emailRequired);
+
+        if (count === 0) {
+          setCount(DB_TIME);
+        }
       }
     }
   };
@@ -120,7 +129,7 @@ function Home() {
                 content={checkAuthCode?.result_data ? '인증완료' : '인증하기'}
                 size="lg"
                 disabled={getButtonStyle('code') || isOpenAuthCode || checkAuthCode?.result_data}
-                onClick={handleEmailAuth}
+                onClick={() => handleEmailAuth('first')}
                 type="button"
               />
               {isOpenAuthCode && (
@@ -151,7 +160,11 @@ function Home() {
                   <div className={S.emailDescription}>
                     <InfoIcon size={13} />
                     <span>이메일을 받지 못하셨나요?</span>
-                    <button type="button" onClick={handleEmailAuth} className={S.emailSendButton}>
+                    <button
+                      type="button"
+                      onClick={() => handleEmailAuth('resend')}
+                      className={S.emailSendButton}
+                    >
                       이메일 재전송하기
                     </button>
                     <AuthCodeTimer count={count} setCount={setCount} />


### PR DESCRIPTION
- Close #161 

## What is this PR? 🔍

- 기능 : 이메일 인증 추가
- issue : #161 

## Changes 📝
- 이메일 인증을 추가했습니다.
- 이메일 인증 플로우
  1. 이메일 입력
  2. '인증하기' 버튼을 누르면 인증 코드 입력창 생성
    - 이메일 값이 바뀌면 인증코드 입력란 사라짐. (시간/입력란 초기화)
     - 5분 지나면 '이메일 재요청하기'버튼 클릭해서 재요청해야 확인 버튼 활성화(DB 5분 적재)
  4. 올바른 코드를 입력 후 '확인'을 누르면 인증창 사라짐
    - 이메일, '인증하기' 비활성화
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/437459ab-8a45-4d08-aa7f-d83ab2c4ea9f)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `npm run lint`
