### PR TITLE
[FEAT] OAuth 로그인 callback 로딩 스피너 구현

### DIFF
--- a/src/apis/queryFunctions/apiClient.ts
+++ b/src/apis/queryFunctions/apiClient.ts
@@ -64,6 +64,7 @@ function createApiClient() {
             console.error('Failed to reissue token:', e);
             localStorage.removeItem('refreshToken');
             sessionStorage.removeItem('accessToken');
+            window.location.href = '/login';
           }
         }
       }

--- a/src/app/oauthcallback/page.tsx
+++ b/src/app/oauthcallback/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { useAuth } from '@/provider/authProvider';
+import { useToast } from '@/provider/toastProvider';
+
+// TODO 로그인을 이미 했다면 로그인 페이지로 못들어가게 하기
+
+function Oauthcallback() {
+  const router = useRouter();
+
+  const { showToast } = useToast();
+  const { setIsLoggedIn } = useAuth();
+
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const accessToken = searchParams.get('access_token');
+    const refreshToken = searchParams.get('refresh_token');
+
+    const handleLogin = () => {
+      if (accessToken && refreshToken) {
+        sessionStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
+        setIsLoggedIn(true);
+        showToast('success', '로그인 되었습니다.');
+
+        router.push('/');
+      } else {
+        showToast('error', '로그인에 실패하였습니다.');
+        router.push('/login');
+      }
+    };
+
+    const timer = setTimeout(handleLogin, 500);
+
+    return () => clearTimeout(timer);
+  }, [router, searchParams, setIsLoggedIn, showToast]);
+
+  return (
+    <div>
+      <LoadingSpinner />
+    </div>
+  );
+}
+
+export default Oauthcallback;

--- a/src/components/LoadingSpinner/LoadingSpinner.css.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.css.ts
@@ -1,0 +1,25 @@
+import { style, keyframes } from '@vanilla-extract/css';
+
+import colors from '@/styles/color';
+
+const spin = keyframes({
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' },
+});
+
+export const spinnerContainer = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100vh',
+  width: '100%',
+});
+
+export const spinner = style({
+  width: '48px',
+  height: '48px',
+  border: '6px solid #f3f3f3',
+  borderTop: `6px solid ${colors.primary9}`,
+  borderRadius: '50%',
+  animation: `${spin} 1s linear infinite`,
+});

--- a/src/components/LoadingSpinner/index.tsx
+++ b/src/components/LoadingSpinner/index.tsx
@@ -1,0 +1,11 @@
+import * as S from './LoadingSpinner.css';
+
+function LoadingSpinner() {
+  return (
+    <div className={S.spinnerContainer}>
+      <div className={S.spinner} />
+    </div>
+  );
+}
+
+export default LoadingSpinner;


### PR DESCRIPTION
- Close #171 

## What is this PR? 🔍

- 기능 : OAuth 로그인 callback 로딩 스피너 구현
- issue : #171 

## Changes 📝

OAuth 로그인 시 aouthcallback으로 넘어오는 순간의 token을 관리하고, 해당 페이지에서의 로딩 스피너를 구현하였습니다.

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

![Oauth callback 구현](https://github.com/user-attachments/assets/783b5202-6abb-4733-98b2-1d66589976ca)


<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `npm run lint`
